### PR TITLE
Add tests covering file split logic, top-level routing, scripts, and settings in rules library

### DIFF
--- a/runner_bre_test.go
+++ b/runner_bre_test.go
@@ -1,0 +1,50 @@
+package yabre
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type BreContext struct {
+	RuleSet      string `json:"rule_set"`
+	TextRuleSet1 string `json:"text_rule_set_1"`
+	TextRuleSet2 string `json:"text_rule_set_2"`
+	TextRuleSet3 string `json:"text_rule_set_3"`
+}
+
+func TestRunnerBre(t *testing.T) {
+	breContext := &BreContext{RuleSet: "ruleset1"}
+	var debugMessage string
+
+	ruleLibrary, err := NewRulesLibrary(RulesLibrarySettings{BasePath: "./test/bre"})
+	assert.NoError(t, err)
+
+	runner, err := NewRulesRunnerFromLibrary(ruleLibrary, "main", breContext,
+		WithDebugCallback[BreContext](
+			func(data ...any) {
+				if len(data) > 0 {
+					debugMessage = fmt.Sprintf("%v", data[0])
+				}
+			}),
+
+		WithDecisionCallback[BreContext](func(msg string, args ...any) {
+			fmt.Printf("    "+msg+"\n", args...)
+		}))
+	assert.NoError(t, err)
+
+	_, err = runner.RunRules(breContext, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "RuleSet1 executed", debugMessage)
+
+	breContext.RuleSet = "ruleset2"
+	_, err = runner.RunRules(breContext, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "RuleSet2 executed", debugMessage)
+
+	breContext.RuleSet = ""
+	_, err = runner.RunRules(breContext, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "RuleSet3 executed", debugMessage)
+}

--- a/test/bre/main.yaml
+++ b/test/bre/main.yaml
@@ -1,0 +1,33 @@
+name: main
+
+require:
+  - ruleset1
+  - ruleset2
+  - ruleset3
+
+conditions:
+  check_for_ruleset1:
+    description: Check if we have to execute ruleset1
+    default: true
+    check: |
+      function() {
+        return context.RuleSet === 'ruleset1' // or more complex logic
+      }
+    true:
+      description: Go to ruleset1
+      next: execute_ruleset1
+    false:
+      next: check_for_ruleset2
+
+  check_for_ruleset2:
+    description: Check if we have to execute ruleset2
+    check: |
+      function() {
+        return context.RuleSet === 'ruleset2' // or more complex logic
+      }
+    true:
+      description: Go to ruleset2
+      next: execute_ruleset2
+    false:
+      description: Go to ruleset3
+      next: execute_ruleset3

--- a/test/bre/ruleset1.yaml
+++ b/test/bre/ruleset1.yaml
@@ -1,0 +1,19 @@
+name: ruleset1
+
+require:
+  - settings
+  - scripts
+
+conditions:
+  execute_ruleset1:
+    check: |
+      function() {
+        return true
+      }
+    true:
+      description: Execute ruleset1
+      action: |
+        function() {
+          debug(executeRuleSet1(context));
+        }
+      terminate: true

--- a/test/bre/ruleset2.yaml
+++ b/test/bre/ruleset2.yaml
@@ -1,0 +1,19 @@
+name: ruleset2
+
+require:
+  - settings
+  - scripts
+
+conditions:
+  execute_ruleset2:
+    check: |
+      function() {
+        return true
+      }
+    true:
+      description: Execute ruleset2
+      action: |
+        function() {
+          debug(executeRuleSet2(context));
+        }
+      terminate: true

--- a/test/bre/ruleset3.yaml
+++ b/test/bre/ruleset3.yaml
@@ -1,0 +1,19 @@
+name: ruleset3
+
+require:
+  - settings
+  - scripts
+
+conditions:
+  execute_ruleset3:
+    check: |
+      function() {
+        return true
+      }
+    true:
+      description: Execute ruleset3
+      action: |
+        function() {
+          debug(executeRuleSet3(context));
+        }
+      terminate: true

--- a/test/bre/scripts.yaml
+++ b/test/bre/scripts.yaml
@@ -1,0 +1,14 @@
+name: scripts
+
+scripts: |
+      function executeRuleSet1(context) {
+        return context.TextRuleSet1;
+      }
+
+      function executeRuleSet2(context) {
+        return context.TextRuleSet2;
+      }
+
+      function executeRuleSet3(context) {
+        return context.TextRuleSet3;
+      }

--- a/test/bre/settings.yaml
+++ b/test/bre/settings.yaml
@@ -1,0 +1,10 @@
+name: settings
+
+scripts: |
+  function defaults() {
+    context.TextRuleSet1 = "RuleSet1 executed";
+    context.TextRuleSet2 = "RuleSet2 executed";
+    context.TextRuleSet3 = "RuleSet3 executed";
+  }
+
+  defaults();


### PR DESCRIPTION
Hi Andrey, have a look and feel free to use or not use it as an example in the yabre space.